### PR TITLE
Add optional executable path

### DIFF
--- a/src/main/config/demojobs.properties.example
+++ b/src/main/config/demojobs.properties.example
@@ -3,12 +3,19 @@
 # Locations for jobtypes and scripts - remove whichever is not relevant on the current system. At least one of these must be defined:
 #   - to install jobtype XML files in the IJP, define 'glassfish' and 'port'
 #   - to install job scripts, define ijp.scripts.dir
+#
+# If ijp.scripts.dir is not on the batch system user's PATH, set executable.path to the same value (but with a trailing /)
 
 # Glassfish home, must contain "glassfish/domains"
 glassfish=/home/br54/glassfish4
 
 # Glassfish admin port (normally 4848)
 port=4848
+
+# Optional path to prefix job executables
+# MUST end with /
+# (Absolute paths may be needed for some batch systems)
+!executable.path=/opt/ijp/bin/
 
 # Location on batch server for job scripts (if current system is an IJP batch server)
 ijp.scripts.dir=/opt/ijp/bin

--- a/src/main/resources/job_types/copy_datafile.xml
+++ b/src/main/resources/job_types/copy_datafile.xml
@@ -9,7 +9,7 @@
         Options: (none)
         Requires sessionId, ICAT and IDS server URLs to be supplied by IJP.
     -->
-    <executable>copy_datafile.py</executable>
+    <executable>${executable.path}copy_datafile.py</executable>
     <multiple>true</multiple>
     <type>batch</type>
     <datasetTypes>${dataset.type.1}</datasetTypes>

--- a/src/main/resources/job_types/copy_datafile_by_link.xml
+++ b/src/main/resources/job_types/copy_datafile_by_link.xml
@@ -9,7 +9,7 @@
         Options: (none)
         Requires sessionId, ICAT and IDS server URLs to be supplied by IJP.
     -->
-    <executable>copy_datafile_by_link.py</executable>
+    <executable>${executable.path}copy_datafile_by_link.py</executable>
     <multiple>true</multiple>
     <type>batch</type>
     <datasetTypes>${dataset.type.1}</datasetTypes>

--- a/src/main/resources/job_types/create_datafile.xml
+++ b/src/main/resources/job_types/create_datafile.xml
@@ -11,7 +11,7 @@
         (For unixbatch, standard PATH for the batch command is very limited,
         so absolute paths may be simplest.)
     -->
-    <executable>create_datafile.py</executable>
+    <executable>${executable.path}create_datafile.py</executable>
     <type>batch</type>
     <datasetTypes>${dataset.type.1}</datasetTypes>
     <jobOptions>

--- a/src/main/resources/job_types/create_version.xml
+++ b/src/main/resources/job_types/create_version.xml
@@ -12,7 +12,7 @@
         (For unixbatch, standard PATH for the batch command is very limited,
         so absolute paths may be simplest.)
     -->
-    <executable>create_version.py</executable>
+    <executable>${executable.path}create_version.py</executable>
     <type>batch</type>
     <datasetTypes>${dataset.type.1}</datasetTypes>
     <jobOptions>

--- a/src/main/resources/job_types/get_datasets_test.xml
+++ b/src/main/resources/job_types/get_datasets_test.xml
@@ -8,7 +8,7 @@
         Options: (none)
         Requires sessionId, ICAT and IDS server URLs to be supplied by IJP.
     -->
-    <executable>get_datasets_test.py</executable>
+    <executable>${executable.path}get_datasets_test.py</executable>
     <multiple>true</multiple>
     <type>batch</type>
     <datasetTypes>${dataset.type.1}</datasetTypes>

--- a/src/main/resources/job_types/get_link_test.xml
+++ b/src/main/resources/job_types/get_link_test.xml
@@ -7,7 +7,7 @@
         Options: (none)
         Requires sessionId, ICAT and IDS server URLs to be supplied by IJP.
     -->
-    <executable>get_link_test.py</executable>
+    <executable>${executable.path}get_link_test.py</executable>
     <multiple>true</multiple>
     <type>batch</type>
     <datasetTypes>${dataset.type.1}</datasetTypes>

--- a/src/main/resources/job_types/pycat_test.xml
+++ b/src/main/resources/job_types/pycat_test.xml
@@ -4,7 +4,7 @@
       It requires no datasets, and has no options.
     -->
     <name>python-icat tests</name>
-    <executable>pycat_test.py</executable>
+    <executable>${executable.path}pycat_test.py</executable>
     <type>batch</type>
     <!-- Job-only jobs can explicitly use "none (job only)" as their datasetType,
          but it is OK to omit the element completely 

--- a/src/main/resources/job_types/sleepcount.xml
+++ b/src/main/resources/job_types/sleepcount.xml
@@ -8,7 +8,7 @@
           (b) the ability (if the batch server supports it) to view job output during execution
     -->
     <name>Sleepcount</name>
-    <executable>sleepcount.bash</executable>
+    <executable>${executable.path}sleepcount.bash</executable>
     <type>batch</type>
     <jobOptions>
       <name>Count</name>

--- a/src/main/resources/job_types/test_args_files_only.xml
+++ b/src/main/resources/job_types/test_args_files_only.xml
@@ -5,7 +5,7 @@
         Run the test_args script, allows single run for all supplied datafiles.
         Does not accept datasets - IJP should not allow their selection.
     -->
-    <executable>test_args.py</executable>
+    <executable>${executable.path}test_args.py</executable>
     <multiple>true</multiple>
     <type>batch</type>
     <datasetTypes>${dataset.type.1}</datasetTypes>

--- a/src/main/resources/job_types/test_args_multi.xml
+++ b/src/main/resources/job_types/test_args_multi.xml
@@ -4,7 +4,7 @@
     <!--
         Run the test_args script, single run for all supplied datasets/datafiles
     -->
-    <executable>test_args.py</executable>
+    <executable>${executable.path}test_args.py</executable>
     <multiple>true</multiple>
     <type>batch</type>
     <datasetTypes>${dataset.type.1}</datasetTypes>

--- a/src/main/resources/job_types/test_args_sets_only.xml
+++ b/src/main/resources/job_types/test_args_sets_only.xml
@@ -5,7 +5,7 @@
         Run the test_args script, allows single run for all supplied datasets.
         Does not accept datafiles - IJP should not allow their selection.
     -->
-    <executable>test_args.py</executable>
+    <executable>${executable.path}test_args.py</executable>
     <multiple>true</multiple>
     <type>batch</type>
     <datasetTypes>${dataset.type.1}</datasetTypes>

--- a/src/main/resources/job_types/test_args_single.xml
+++ b/src/main/resources/job_types/test_args_single.xml
@@ -4,7 +4,7 @@
     <!--
         Run the test_args script, one run per dataset/datafile
     -->
-    <executable>test_args.py</executable>
+    <executable>${executable.path}test_args.py</executable>
     <type>batch</type>
     <datasetTypes>${dataset.type.1}</datasetTypes>
     <!-- test_args.py supports option-{one,two}; we don't have to use them here -->

--- a/src/main/resources/job_types/test_options.xml
+++ b/src/main/resources/job_types/test_options.xml
@@ -8,7 +8,7 @@
         covering each of the option types: string, string-with-default, boolean group,
         boolean solo, enumeration, integer and float.
     -->
-    <executable>test_args.py</executable>
+    <executable>${executable.path}test_args.py</executable>
     <multiple>true</multiple>
     <type>batch</type>
     <datasetTypes>${dataset.type.1}</datasetTypes>

--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -47,10 +47,10 @@ def substProps( filename, propsList ):
 actions, options, arg = getActions()
 
 prop_name = "demojobs.properties"
-optional_prop_list = ['glassfish','port', "ijp.scripts.dir"]
+optional_prop_list = ['glassfish','port', 'ijp.scripts.dir','executable.path']
 mandatory_prop_list = ["facility.name","data.format.name","data.format.version","dataset.type.1","dataset.type.2"]
 # Properties to replace in jobtype files
-jobtype_props = ["dataset.type.1","dataset.type.2"]
+jobtype_props = ["dataset.type.1","dataset.type.2","executable.path"]
 # Properties to replace in the icat_defs.py script
 script_props = ["facility.name","data.format.name","data.format.version"]
 
@@ -59,11 +59,14 @@ if arg in ["CONFIGURE", "INSTALL"]:
     actions.configure(prop_name,mandatory_prop_list,".")
     props = actions.getProperties(prop_name, mandatory_prop_list)
     # ... but at least one of them must be set
-    if (not props['glassfish']) and (not props['ijp.scripts.dir']):
+    if (not 'glassfish' in props) and (not 'ijp.scripts.dir' in props):
         abort("At least one of glassfish or ijp.scripts.dir must be specified in " + prop_name)
     # and if glassfish is set, port must be set too
-    if props['glassfish'] and not props['port']:
+    if 'glassfish' in props and not 'port' in props:
         abort('Must specify port for glassfish')
+    # if executable.path is not set, set it to the empty string
+    if not 'executable.path' in props:
+        props['executable.path'] = ''
     actions.checkNoErrors()
     
 if arg == "INSTALL":   
@@ -76,7 +79,7 @@ if arg == "INSTALL":
         mf = open(manifest_name,'w')
         
         # if glassfish is defined, copy jobtypes/*.xml to domainN/config/ijp/job_types there
-        if props['glassfish']:
+        if 'glassfish' in props:
             # use getGlassfish() to set config_path
             actions.getGlassfish(prop_name,[])
             jobtypes_dir = os.path.join(actions.config_path,'ijp/job_types')
@@ -92,7 +95,7 @@ if arg == "INSTALL":
                 substProps(os.path.join(jobtypes_dir,file),jobtype_props)
                 
         # if ijp.scripts.dir is defined, copy {bash,python}/* to there
-        if props['ijp.scripts.dir']:
+        if 'ijp.scripts.dir' in props:
             scripts_dir = os.path.normpath(props['ijp.scripts.dir'])
             for file in glob.glob("bash/*"):
                 shutil.copy(file,scripts_dir)

--- a/src/site/xdoc/installation.xml.vm
+++ b/src/site/xdoc/installation.xml.vm
@@ -40,6 +40,9 @@
                         Several jobscripts require Python-ICAT to be installed on the batch server.
                     </li>
                     <li>
+                        The <code>create_version</code> jobscript requires the python versioning API <code>vicat.py</code> to be present.
+                    </li>
+                    <li>
                         <code>sleepcount</code> is a bash script, so requires <code>bash</code> on the batch server.
                     </li>
                     <li>
@@ -79,8 +82,8 @@
                     </li>
                     <li>
                       The batch scripts folder must be visible to the batch system userids that will be used to run jobs
-                      (it should be in their <code>PATH</code>). If this is not possible, then change the executable in each
-                      jobtype to use the full path.
+                      (it should be in their <code>PATH</code>). If this is not possible, then set the <code>executable.path</code>
+                      property in <code>demojobs.properties</code> to the absolute path.  Note that it must end with a <code>/</code>.
                       Current IJP batch servers use <code>sudo</code> to execute scripts; one consequence is that the scripts
                       folder must also be permitted by the sudoers security policy (typically, it should be one of the values
                       in <code>secure_path</code> in the <code>/etc/sudoers</code> file.)
@@ -101,6 +104,11 @@
                     <dt>port</dt>
                     <dd>The admin port of the glassfish instance, e.g. 4848.
                       When the <code>glassfish</code> property is specified, this must be specified as well.
+                    </dd>
+                    
+                    <dt>executable.path</dt>
+                    <dd>Optional. If the scripts will be installed in a folder that is not on the batch system user's PATH,
+                      then set this value to the absolute path for this folder. The value must end with a <code>/</code>.
                     </dd>
                     
                     <dt>ijp.scripts.dir</dt>

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -11,8 +11,10 @@
             <li>Added scripts that use python-icat</li>
             <li>Added script demonstrating more of the job option types</li>
             <li>Added demo of use of IDS preparedData</li>
+            <li>Added script to create new version of a dataset</li>
             <li>Change setup to cope with missing files in its manifest</li>
             <li>Removed forward-slash from jobtype names (can cause problems in REST calls)</li>
+            <li>Added optional executable path for jobtypes in configuration</li>
             </ul>
         </section>
         <section name="1.0.0">


### PR DESCRIPTION
Added executable.path to demojobs.properties; modified most jobscripts
to use it. Modified setup script to make the empty string the default
value (also fixed a coding error). Updated installation documentation
and release notes.