### PR TITLE
Add optional second directory for jobtypes

### DIFF
--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -47,7 +47,7 @@ def substProps( filename, propsList ):
 actions, options, arg = getActions()
 
 prop_name = "demojobs.properties"
-optional_prop_list = ['glassfish','port', 'ijp.scripts.dir','executable.path']
+optional_prop_list = ['glassfish','port', 'ijp.scripts.dir','executable.path','ijp.jobtypes.dir.2']
 mandatory_prop_list = ["facility.name","data.format.name","data.format.version","dataset.type.1","dataset.type.2"]
 # Properties to replace in jobtype files
 jobtype_props = ["dataset.type.1","dataset.type.2","executable.path"]
@@ -85,14 +85,22 @@ if arg == "INSTALL":
             jobtypes_dir = os.path.join(actions.config_path,'ijp/job_types')
             for file in glob.glob("job_types/*.xml"):
                 shutil.copy(file,jobtypes_dir)
-                file = os.path.basename(file)
-                mf.write(os.path.join(jobtypes_dir,file)+'\n')
+                filename = os.path.basename(file)
+                mf.write(os.path.join(jobtypes_dir,filename)+'\n')
                 if actions.verbosity:
-                    print "Added " + file + " to " + jobtypes_dir
+                    print "Added " + filename + " to " + jobtypes_dir
                 # Substitute dataset types, if any
                 if actions.verbosity:
-                    print "Replacing any dataset type references in " + file
-                substProps(os.path.join(jobtypes_dir,file),jobtype_props)
+                    print "Replacing any dataset type references in " + filename
+                substProps(os.path.join(jobtypes_dir,filename),jobtype_props)
+                # If a second location is specified, copy the file to there as well
+                if 'ijp.jobtypes.dir.2' in props:
+                    jobtypesDir2 = props['ijp.jobtypes.dir.2']
+                    if actions.verbosity:
+                        print "Copying jobtype " + filename + " to " + jobtypesDir2
+                    file2 = os.path.join(jobtypesDir2,filename)
+                    shutil.copy(os.path.join(jobtypes_dir,filename),file2)
+                    mf.write(file2 + '\n')
                 
         # if ijp.scripts.dir is defined, copy {bash,python}/* to there
         if 'ijp.scripts.dir' in props:

--- a/src/site/xdoc/installation.xml.vm
+++ b/src/site/xdoc/installation.xml.vm
@@ -73,6 +73,10 @@
                         When the IJP and batch server are separate systems, the installation must be performed once on each, with only the
                         glassfish location and admin port defined for the IJP server, and only the scripts location defined for the batch server.
                     </li>
+                    <li>Normally, when the IJP server is redeployed, it will replace any jobtypes installed in glassfish
+                        with those specified in its own configuration. To overcome this and preserve the demo jobtypes,
+                        set <code>ijp.jobtypes.dir.2</code> in the properties with the path to the IJP server installation.
+                    </li>
                     <li>
                         Change the dataset types, facilty name and data format details in the properties file; the chosen values
                         must be existing entities in the ICAT instance used by the IJP.  See below for more details.
@@ -109,6 +113,12 @@
                     <dt>executable.path</dt>
                     <dd>Optional. If the scripts will be installed in a folder that is not on the batch system user's PATH,
                       then set this value to the absolute path for this folder. The value must end with a <code>/</code>.
+                    </dd>
+                    
+                    <dt>ijp.jobtypes.dir.2</dt>
+                    <dd>Optional second location for the jobtype XML files. This can be used to add the jobtypes to
+                    the install folder of <code>ijp.server</code> (e.g. <code>/home/dmf/install/ijp.server/ijp/job_types</code>.
+                    Redeploying the IJP server would otherwise replace the demo jobtypes in the glassfish configuration.
                     </dd>
                     
                     <dt>ijp.scripts.dir</dt>

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -15,6 +15,7 @@
             <li>Change setup to cope with missing files in its manifest</li>
             <li>Removed forward-slash from jobtype names (can cause problems in REST calls)</li>
             <li>Added optional executable path for jobtypes in configuration</li>
+            <li>Added optional second location to copy jobtypes</li>
             </ul>
         </section>
         <section name="1.0.0">


### PR DESCRIPTION
Modified setup script to allow an optional second location for jobtype
files; mainly so they can be copied to the ijp.server configuration, so
that redeploying ijp.server does not remove them from glassfish.